### PR TITLE
Windows environment name

### DIFF
--- a/flask-server/server.py
+++ b/flask-server/server.py
@@ -10,8 +10,8 @@ from dotenv import load_dotenv
 from werkzeug.utils import secure_filename
 
 load_dotenv()
-DB_USERNAME = os.environ.get("username")
-DB_PASSWORD = os.environ.get("password")
+DB_USERNAME = os.environ.get("db_username")
+DB_PASSWORD = os.environ.get("db_password")
 
 # adds the classes folder to the path
 script_dir = os.path.dirname(__file__)


### PR DESCRIPTION
Fixed the issue where on windows os.environ.get('username') would return the local users current name instead of the name in the environemt file by replacing username with db_username.